### PR TITLE
Simplify regexes and minor cleanup

### DIFF
--- a/StreamingTwitter.py
+++ b/StreamingTwitter.py
@@ -55,10 +55,9 @@ class CustomStreamListener(tweepy.StreamListener):
             
             final_tweet = '|positive|, |%s| ' % (Tweet)
 
-            f = open('YourFileHereName', 'r+')
-            old = f.read()
-            f.write(final_tweet+'\n')
-            f.close()
+            with open('YourFileHereName', 'r+') as f:
+                old = f.read()
+                f.write(final_tweet+'\n')
         
             self.n = self.n+1
             if self.n < 3000: 
@@ -123,10 +122,9 @@ class CustomStreamListenerNEG(tweepy.StreamListener):
             
             final_tweet = '|negative|, |%s| ' % (Tweet)
             
-            f = open('YourFileHereName', 'r+')
-            old = f.read()
-            f.write(final_tweet+'\n')
-            f.close()
+            with open('YourFileHereName', 'r+') as f:
+                old = f.read()
+                f.write(final_tweet+'\n')
         
             self.n = self.n+1
             if self.n < 3000: 

--- a/StreamingTwitter.py
+++ b/StreamingTwitter.py
@@ -33,7 +33,7 @@ class CustomStreamListener(tweepy.StreamListener):
             Tweet = re.sub('@\S+','TWITTER_USER',Tweet)
             
             #Remove additional white spaces
-            tweet = re.sub('\s+', ' ', Tweet)
+            Tweet = re.sub('\s+', ' ', Tweet)
             
             #Replace #word with word Handling hashtags
             Tweet = re.sub(r'#(\S+)', r'\1', Tweet)
@@ -101,7 +101,7 @@ class CustomStreamListenerNEG(tweepy.StreamListener):
             Tweet = re.sub('@\S+','TWITTER_USER',Tweet)
             
             #Remove additional white spaces
-            tweet = re.sub('\s+', ' ', Tweet)
+            Tweet = re.sub('\s+', ' ', Tweet)
             
             #Replace #word with word Handling hashtags
             Tweet = re.sub(r'#(\S+)', r'\1', Tweet)

--- a/StreamingTwitter.py
+++ b/StreamingTwitter.py
@@ -19,8 +19,6 @@ class CustomStreamListener(tweepy.StreamListener):
 
     def on_status(self, status):
         try:
-            tweets = []
-            name = status.author.screen_name
             textTwitter = status.text
             
             #Convert into lowercase
@@ -86,8 +84,6 @@ class CustomStreamListenerNEG(tweepy.StreamListener):
 
     def on_status(self, status):
         try:
-            tweets = []
-            name = status.author.screen_name
             textTwitter = status.text
             
             #Convert into lowercase

--- a/StreamingTwitter.py
+++ b/StreamingTwitter.py
@@ -27,16 +27,16 @@ class CustomStreamListener(tweepy.StreamListener):
             Tweet = textTwitter.lower()
             
             #Convert www.* or https?://* to URL
-            Tweet = re.sub('((www\.[\s]+)|(https?://[^\s]+))','URL',Tweet)
+            Tweet = re.sub('((www\.\S+)|(https?://\S+))','URL',Tweet)
             
             #Convert @username to User
-            Tweet = re.sub('@[^\s]+','TWITTER_USER',Tweet)
+            Tweet = re.sub('@\S+','TWITTER_USER',Tweet)
             
             #Remove additional white spaces
-            tweet = re.sub('[\s]+', ' ', Tweet)
+            tweet = re.sub('\s+', ' ', Tweet)
             
             #Replace #word with word Handling hashtags
-            Tweet = re.sub(r'#([^\s]+)', r'\1', Tweet)
+            Tweet = re.sub(r'#(\S+)', r'\1', Tweet)
             
             #trim
             Tweet = Tweet.strip('\'"')
@@ -95,16 +95,16 @@ class CustomStreamListenerNEG(tweepy.StreamListener):
             Tweet = textTwitter.lower()
             
             #Convert www.* or https?://* to URL
-            Tweet = re.sub('((www\.[\s]+)|(https?://[^\s]+))','URL',Tweet)
+            Tweet = re.sub('((www\.\S+)|(https?://\S+))','URL',Tweet)
             
             #Convert @username to TWITTER_USER
-            Tweet = re.sub('@[^\s]+','TWITTER_USER',Tweet)
+            Tweet = re.sub('@\S+','TWITTER_USER',Tweet)
             
             #Remove additional white spaces
-            tweet = re.sub('[\s]+', ' ', Tweet)
+            tweet = re.sub('\s+', ' ', Tweet)
             
             #Replace #word with word Handling hashtags
-            Tweet = re.sub(r'#([^\s]+)', r'\1', Tweet)
+            Tweet = re.sub(r'#(\S+)', r'\1', Tweet)
             
             #trim
             Tweet = Tweet.strip('\'"')


### PR DESCRIPTION
Some regex meta-sequences have various forms: ` \w` matches any word character, and `\W` matches any non word character. `\d` and `\D` follow the same logic for digits. Some are less common, like `\h` and `\H` and `\v` and `\V` for horizontal and vertical whitespaces (and their non-vertical/horizontal whitespace twins).
Finally, character ranges (`[..]`) let us specify a range of matching characters, and the opposite is the "any-but" range: `[^..]`.
But using an any-but character range with a single range, which also offers it's exclusive version is an anti-pattern, adding noise to the regex and making it harder to read and maintain. 

In this PR, I cleaned all the `[^\s]+` which is equivalent of `\S+` (no range needed!), and `[^\S]+` which is equivalent of `\s+`

As a proof of the unneeded noise making the intent of the regex less obvious, there was a bug: the cleaning done for `www....` and `https://....` url wasn't the same (and wrong for the simple www form), which is fixed in this PR


In the last commits I did some cleanup of a few unused vars, but others are still there (I didn't want to make too many changes at the same time, since my initial goal was to make the regex pattern simpler and more efficient), and I just did a small change for file opening, to follow the usual best practices to open the file within an `with open` indentation so that Python deals with automatic file closing when this block is exited (from normal script run or from an exception)
 
As a final note, there are many other room for improvements:
- unused imports could be removed
- twitter token should (imho) not be in the code, and I'd invalidate them in twitter and load these values (either form environment variables, or from a file) and pdate the readme accordingly, but if it were my own tokens, I wouldn't be comfortable having them accessible to everyone.
